### PR TITLE
Use sccache instead of ccache

### DIFF
--- a/.github/actions/gcloud-login/action.yml
+++ b/.github/actions/gcloud-login/action.yml
@@ -4,8 +4,17 @@ inputs:
   private_key:
     description: The service account private key, in JSON format, base64-encoded
     required: true
+  write_keyfile_to:
+    description: Write the keyfile to the given path
+    required: false
 runs:
   using: composite
   steps:
     - run: gcloud auth activate-service-account --key-file <(base64 -d <<< "${{ inputs.private_key }}")
       shell: bash
+    - run: base64 -d <<< "$PRIVATE_KEY" > "$OUTPUT"
+      shell: bash
+      if: inputs.write_keyfile_to != ''
+      env:
+        PRIVATE_KEY: ${{ inputs.private_key }}
+        OUTPUT: ${{ inputs.write_keyfile_to }}

--- a/.github/workflows/ci-cd-build-packages-1.yml
+++ b/.github/workflows/ci-cd-build-packages-1.yml
@@ -26,6 +26,7 @@ on:
 env:
   CI_ARTIFACTS_BUCKET: fullstaq-ruby-server-edition-ci-artifacts
   CI_ARTIFACTS_RUN_NUMBER: ${{ github.event.inputs.ci_artifacts_run_number || github.run_number }}
+  CACHE_CONTAINER: server-edition-ci-cache
 
 jobs:
   # Determines which jobs should be run, or (in case this is a re-run)
@@ -93,13 +94,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-centos-7-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -113,6 +112,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -122,6 +123,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'centos-7'
+          CACHE_KEY_PREFIX: 'sccache/centos-7'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -140,13 +142,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-debian-9-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -160,6 +160,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -169,6 +171,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'debian-9'
+          CACHE_KEY_PREFIX: 'sccache/debian-9'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -203,6 +206,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -235,20 +243,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -288,6 +289,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -325,20 +331,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -378,6 +377,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -410,20 +414,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -463,6 +460,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -495,20 +497,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -548,6 +543,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -585,20 +585,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -638,6 +631,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -670,20 +668,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -723,6 +714,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -755,20 +751,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -808,6 +797,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -845,20 +839,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -898,6 +885,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -930,20 +922,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -983,6 +968,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1015,20 +1005,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1068,6 +1051,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1105,20 +1093,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1158,6 +1139,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1190,20 +1176,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1243,6 +1222,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1275,20 +1259,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1328,6 +1305,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1365,20 +1347,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1418,6 +1393,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1450,20 +1430,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1503,6 +1476,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1535,20 +1513,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-centos-7-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1588,6 +1559,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1625,20 +1601,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-7
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-centos-7-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1678,6 +1647,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1710,20 +1684,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-centos-7-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-7"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-7"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1764,6 +1731,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1796,20 +1768,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1849,6 +1814,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1886,20 +1856,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1939,6 +1902,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1971,20 +1939,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2024,6 +1985,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2056,20 +2022,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2109,6 +2068,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2146,20 +2110,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2199,6 +2156,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2231,20 +2193,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2284,6 +2239,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2316,20 +2276,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2369,6 +2322,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2406,20 +2364,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2459,6 +2410,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2491,20 +2447,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2544,6 +2493,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2576,20 +2530,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2629,6 +2576,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2666,20 +2618,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2719,6 +2664,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2751,20 +2701,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2804,6 +2747,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2836,20 +2784,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2889,6 +2830,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2926,20 +2872,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2979,6 +2918,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3011,20 +2955,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3064,6 +3001,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3096,20 +3038,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-debian-9-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3149,6 +3084,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3186,20 +3126,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-9
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-debian-9-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3239,6 +3172,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3271,20 +3209,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-debian-9-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-9"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-9"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh

--- a/.github/workflows/ci-cd-build-packages-2.yml
+++ b/.github/workflows/ci-cd-build-packages-2.yml
@@ -26,6 +26,7 @@ on:
 env:
   CI_ARTIFACTS_BUCKET: fullstaq-ruby-server-edition-ci-artifacts
   CI_ARTIFACTS_RUN_NUMBER: ${{ github.event.inputs.ci_artifacts_run_number || github.run_number }}
+  CACHE_CONTAINER: server-edition-ci-cache
 
 jobs:
   # Determines which jobs should be run, or (in case this is a re-run)
@@ -93,13 +94,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-centos-8-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -113,6 +112,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -122,6 +123,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'centos-8'
+          CACHE_KEY_PREFIX: 'sccache/centos-8'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -140,13 +142,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-ubuntu-18.04-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -160,6 +160,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -169,6 +171,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'ubuntu-18.04'
+          CACHE_KEY_PREFIX: 'sccache/ubuntu-18.04'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -203,6 +206,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -235,20 +243,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -288,6 +289,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -325,20 +331,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -378,6 +377,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -410,20 +414,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -463,6 +460,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -495,20 +497,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -548,6 +543,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -585,20 +585,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -638,6 +631,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -670,20 +668,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -723,6 +714,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -755,20 +751,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -808,6 +797,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -845,20 +839,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -898,6 +885,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -930,20 +922,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -983,6 +968,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1015,20 +1005,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1068,6 +1051,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1105,20 +1093,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1158,6 +1139,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1190,20 +1176,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1243,6 +1222,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1275,20 +1259,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1328,6 +1305,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1365,20 +1347,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1418,6 +1393,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1450,20 +1430,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1503,6 +1476,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1535,20 +1513,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-centos-8-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1588,6 +1559,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1625,20 +1601,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-centos-8
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-centos-8-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1678,6 +1647,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1710,20 +1684,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-centos-8-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "centos-8"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/centos-8"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1764,6 +1731,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1796,20 +1768,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1849,6 +1814,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1886,20 +1856,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1939,6 +1902,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1971,20 +1939,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2024,6 +1985,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2056,20 +2022,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2109,6 +2068,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2146,20 +2110,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2199,6 +2156,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2231,20 +2193,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2284,6 +2239,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2316,20 +2276,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2369,6 +2322,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2406,20 +2364,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2459,6 +2410,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2491,20 +2447,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2544,6 +2493,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2576,20 +2530,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2629,6 +2576,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2666,20 +2618,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2719,6 +2664,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2751,20 +2701,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2804,6 +2747,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2836,20 +2784,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2889,6 +2830,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2926,20 +2872,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2979,6 +2918,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3011,20 +2955,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3064,6 +3001,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3096,20 +3038,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-ubuntu-18.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3149,6 +3084,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3186,20 +3126,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-18.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-ubuntu-18.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3239,6 +3172,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3271,20 +3209,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-ubuntu-18.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-18.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-18.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh

--- a/.github/workflows/ci-cd-build-packages-3.yml
+++ b/.github/workflows/ci-cd-build-packages-3.yml
@@ -26,6 +26,7 @@ on:
 env:
   CI_ARTIFACTS_BUCKET: fullstaq-ruby-server-edition-ci-artifacts
   CI_ARTIFACTS_RUN_NUMBER: ${{ github.event.inputs.ci_artifacts_run_number || github.run_number }}
+  CACHE_CONTAINER: server-edition-ci-cache
 
 jobs:
   # Determines which jobs should be run, or (in case this is a re-run)
@@ -93,13 +94,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-debian-10-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -113,6 +112,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -122,6 +123,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'debian-10'
+          CACHE_KEY_PREFIX: 'sccache/debian-10'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -140,13 +142,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-ubuntu-20.04-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -160,6 +160,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -169,6 +171,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'ubuntu-20.04'
+          CACHE_KEY_PREFIX: 'sccache/ubuntu-20.04'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -203,6 +206,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -235,20 +243,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -288,6 +289,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -325,20 +331,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -378,6 +377,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -410,20 +414,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -463,6 +460,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -495,20 +497,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -548,6 +543,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -585,20 +585,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -638,6 +631,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -670,20 +668,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -723,6 +714,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -755,20 +751,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -808,6 +797,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -845,20 +839,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -898,6 +885,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -930,20 +922,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -983,6 +968,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1015,20 +1005,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1068,6 +1051,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1105,20 +1093,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1158,6 +1139,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1190,20 +1176,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1243,6 +1222,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1275,20 +1259,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1328,6 +1305,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1365,20 +1347,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1418,6 +1393,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1450,20 +1430,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1503,6 +1476,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1535,20 +1513,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-debian-10-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1588,6 +1559,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1625,20 +1601,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-10
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-debian-10-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1678,6 +1647,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1710,20 +1684,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-debian-10-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-10"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-10"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1764,6 +1731,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1796,20 +1768,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1849,6 +1814,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1886,20 +1856,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1939,6 +1902,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1971,20 +1939,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2024,6 +1985,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2056,20 +2022,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2109,6 +2068,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2146,20 +2110,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2199,6 +2156,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2231,20 +2193,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2284,6 +2239,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2316,20 +2276,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2369,6 +2322,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2406,20 +2364,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2459,6 +2410,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2491,20 +2447,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2544,6 +2493,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2576,20 +2530,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2629,6 +2576,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2666,20 +2618,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2719,6 +2664,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2751,20 +2701,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2804,6 +2747,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2836,20 +2784,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2889,6 +2830,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -2926,20 +2872,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -2979,6 +2918,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3011,20 +2955,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3064,6 +3001,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3096,20 +3038,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-ubuntu-20.04-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3149,6 +3084,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3186,20 +3126,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-ubuntu-20.04
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-ubuntu-20.04-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -3239,6 +3172,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -3271,20 +3209,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-ubuntu-20.04-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "ubuntu-20.04"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/ubuntu-20.04"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh

--- a/.github/workflows/ci-cd-build-packages-4.yml
+++ b/.github/workflows/ci-cd-build-packages-4.yml
@@ -26,6 +26,7 @@ on:
 env:
   CI_ARTIFACTS_BUCKET: fullstaq-ruby-server-edition-ci-artifacts
   CI_ARTIFACTS_RUN_NUMBER: ${{ github.event.inputs.ci_artifacts_run_number || github.run_number }}
+  CACHE_CONTAINER: server-edition-ci-cache
 
 jobs:
   # Determines which jobs should be run, or (in case this is a re-run)
@@ -93,13 +94,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
-      - name: Fetch cache
-        uses: actions/cache@v1
-        with:
-          path: cache
-          key: 'jemalloc-bin-debian-11-3.6.0'
-      - name: Create cache dir
-        run: mkdir -p cache
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
       - name: Download Docker image necessary for building
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -113,6 +112,8 @@ jobs:
         env:
           TARBALL: image.tar.zst
 
+      - run: mkdir cache
+
       - name: Download source
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
         env:
@@ -122,6 +123,7 @@ jobs:
         run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
         env:
           ENVIRONMENT_NAME: 'debian-11'
+          CACHE_KEY_PREFIX: 'sccache/debian-11'
 
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -156,6 +158,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -188,20 +195,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -241,6 +241,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -278,20 +283,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -331,6 +329,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -363,20 +366,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -416,6 +412,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -448,20 +449,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -501,6 +495,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -538,20 +537,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -591,6 +583,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -623,20 +620,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -676,6 +666,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -708,20 +703,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -761,6 +749,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -798,20 +791,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -851,6 +837,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -883,20 +874,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -936,6 +920,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -968,20 +957,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.1.2-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1021,6 +1003,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1058,20 +1045,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.1.2-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1111,6 +1091,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1143,20 +1128,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.1.2-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.1.2"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1196,6 +1174,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1228,20 +1211,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-3.0.4-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1281,6 +1257,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1318,20 +1299,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-3.0.4-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1371,6 +1345,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1403,20 +1382,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-3.0.4-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "3.0.4"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1456,6 +1428,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1488,20 +1465,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-normal
-      - name: "[normal] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-normal
-          key: v2-ruby-bin-2.7.6-debian-11-normal
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "normal"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1541,6 +1511,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1578,20 +1553,13 @@ jobs:
           ARTIFACT_NAME: jemalloc-bin-debian-11
           ARTIFACT_PATH: .        
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-jemalloc
-      - name: "[jemalloc] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-jemalloc
-          key: v2-ruby-bin-2.7.6-debian-11-jemalloc
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "jemalloc"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh
@@ -1631,6 +1599,11 @@ jobs:
         uses: ./.github/actions/gcloud-login
         with:
           private_key: ${{ secrets.GCLOUD_KEY }}
+          write_keyfile_to: gcloud-credentials.json
+      - name: Dump Azure connection string
+        run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+        env:
+          CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
       - name: Fetch Ruby source
         run: ./internal-scripts/ci-cd/download-artifact.sh
         env:
@@ -1663,20 +1636,13 @@ jobs:
 
       
 
-      - name: Reset & prepare workspace
-        run: mkdir cache-malloctrim
-      - name: "[malloctrim] Fetch cache"
-        uses: actions/cache@v2
-        with:
-          path: cache-malloctrim
-          key: v2-ruby-bin-2.7.6-debian-11-malloctrim
-
       - name: Build binaries
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
         env:
           ENVIRONMENT_NAME: "debian-11"
           VARIANT_NAME: "malloctrim"
           RUBY_PACKAGE_VERSION_ID: "2.7.6"
+          CACHE_KEY_PREFIX: "sccache/debian-11"
 
       - name: Build package
         run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh

--- a/.github/workflows/ci-cd-build-packages.yml.erb
+++ b/.github/workflows/ci-cd-build-packages.yml.erb
@@ -16,6 +16,7 @@ on:
 env:
   CI_ARTIFACTS_BUCKET: fullstaq-ruby-server-edition-ci-artifacts
   CI_ARTIFACTS_RUN_NUMBER: ${{ github.event.inputs.ci_artifacts_run_number || github.run_number }}
+  CACHE_CONTAINER: server-edition-ci-cache
 
 jobs:
   # Determines which jobs should be run, or (in case this is a re-run)
@@ -84,13 +85,11 @@ jobs:
           uses: ./.github/actions/gcloud-login
           with:
             private_key: ${{ secrets.GCLOUD_KEY }}
-        - name: Fetch cache
-          uses: actions/cache@v1
-          with:
-            path: cache
-            key: 'jemalloc-bin-<%= distribution[:name] %>-<%= jemalloc_version %>'
-        - name: Create cache dir
-          run: mkdir -p cache
+            write_keyfile_to: gcloud-credentials.json
+        - name: Dump Azure connection string
+          run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+          env:
+            CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
 
         - name: Download Docker image necessary for building
           run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -104,6 +103,8 @@ jobs:
           env:
             TARBALL: image.tar.zst
 
+        - run: mkdir cache
+
         - name: Download source
           run: ./internal-scripts/ci-cd/build-jemalloc-binaries/download-source.sh
           env:
@@ -113,6 +114,7 @@ jobs:
           run: ./internal-scripts/ci-cd/build-jemalloc-binaries/build.sh
           env:
             ENVIRONMENT_NAME: '<%= distribution[:name] %>'
+            CACHE_KEY_PREFIX: 'sccache/<%= distribution[:name] %>'
 
         - name: Archive artifact
           run: ./internal-scripts/ci-cd/upload-artifact.sh
@@ -151,6 +153,11 @@ jobs:
           uses: ./.github/actions/gcloud-login
           with:
             private_key: ${{ secrets.GCLOUD_KEY }}
+            write_keyfile_to: gcloud-credentials.json
+        - name: Dump Azure connection string
+          run: echo -n "$CONNECTION_STRING" > azure-connection-string.txt
+          env:
+            CONNECTION_STRING: ${{ secrets.AZURE_CI1_STORAGE_CONNECTION_STRING }}
         - name: Fetch Ruby source
           run: ./internal-scripts/ci-cd/download-artifact.sh
           env:
@@ -191,20 +198,13 @@ jobs:
         <%- end -%>
         <% end %>
 
-        - name: Reset & prepare workspace
-          run: mkdir cache-<%= variant[:name] %>
-        - name: "[<%= variant[:name] %>] Fetch cache"
-          uses: actions/cache@v2
-          with:
-            path: cache-<%= variant[:name] %>
-            key: v2-ruby-bin-<%= ruby_package_version[:id] %>-<%= distribution[:name] %>-<%= variant[:name] %>
-
         - name: Build binaries
           run: ./internal-scripts/ci-cd/build-ruby-packages/build-binaries.sh
           env:
             ENVIRONMENT_NAME: "<%= distribution[:name] %>"
             VARIANT_NAME: "<%= variant[:name] %>"
             RUBY_PACKAGE_VERSION_ID: "<%= ruby_package_version[:id] %>"
+            CACHE_KEY_PREFIX: "sccache/<%= distribution[:name] %>"
 
         - name: Build package
           run: ./internal-scripts/ci-cd/build-ruby-packages/build-package.sh

--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -177,14 +177,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-centos-7'
-          IMAGE_TAG: '3'
+          IMAGE_TAG: '4'
           SOURCE_DIR: 'environments/centos-7'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-centos-7'
-          IMAGE_TAG: '3'
+          IMAGE_TAG: '4'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -208,14 +208,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-centos-8'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
           SOURCE_DIR: 'environments/centos-8'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-centos-8'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -239,14 +239,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-10'
-          IMAGE_TAG: '1'
+          IMAGE_TAG: '2'
           SOURCE_DIR: 'environments/debian-10'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-10'
-          IMAGE_TAG: '1'
+          IMAGE_TAG: '2'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -270,14 +270,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-11'
-          IMAGE_TAG: '1'
+          IMAGE_TAG: '2'
           SOURCE_DIR: 'environments/debian-11'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-11'
-          IMAGE_TAG: '1'
+          IMAGE_TAG: '2'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -301,14 +301,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-9'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
           SOURCE_DIR: 'environments/debian-9'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-debian-9'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -332,14 +332,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-ubuntu-18.04'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
           SOURCE_DIR: 'environments/ubuntu-18.04'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-ubuntu-18.04'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -363,14 +363,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-ubuntu-20.04'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
           SOURCE_DIR: 'environments/ubuntu-20.04'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'fullstaq/ruby-build-env-ubuntu-20.04'
-          IMAGE_TAG: '2'
+          IMAGE_TAG: '3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:

--- a/build-jemalloc
+++ b/build-jemalloc
@@ -10,7 +10,9 @@ ENVIRONMENT_NAME=
 SOURCE_PATH=
 OUTPUT_PATH=
 BUILD_CONCURRENCY=1
-CACHE_PATH=
+CACHE_CONNECTION_STRING_FILE=
+CACHE_CONTAINER=
+CACHE_KEY_PREFIX=
 
 function usage()
 {
@@ -18,22 +20,23 @@ function usage()
     echo "Build a Jemalloc binary tarball from its source tarball."
     echo
     echo "Required options:"
-    echo "  -n NAME     Name of environment to build in (one of: $(list_environment_names "$SELFDIR/environments"))"
-    echo "  -s PATH     Path to Jemalloc source tarball"
-    echo "  -o PATH     Path to output tarball"
+    echo "  -n NAME      Name of environment to build in (one of: $(list_environment_names "$SELFDIR/environments"))"
+    echo "  -s PATH      Path to Jemalloc source tarball"
+    echo "  -o PATH      Path to output tarball"
     echo
     echo "Optional options:"
-    echo "  -j NUM      Build concurrency (default: $BUILD_CONCURRENCY)"
-    echo "  -c PATH     Use given directory as cache"
-    echo "  -h          Show usage"
+    echo "  -j NUM       Build concurrency (default: $BUILD_CONCURRENCY)"
+    echo "  -c PATH      Cache to Azure Blob Storage, use connection string in given file"
+    echo "  -r CONTAINER Use given Azure Blob Storage container"
+    echo "  -d NAME      Use given Azure Blob Storage key prefix"
+    echo "  -h           Show usage"
 }
 
 function parse_options()
 {
     local OPTIND=1
-    local ORIG_ARGV
     local opt
-    while getopts "n:s:o:j:c:h" opt; do
+    while getopts "n:s:o:j:c:r:d:h" opt; do
         case "$opt" in
         n)
             ENVIRONMENT_NAME="$OPTARG"
@@ -48,7 +51,13 @@ function parse_options()
             BUILD_CONCURRENCY="$OPTARG"
             ;;
         c)
-            CACHE_PATH=$(absolute_path "$OPTARG")
+            CACHE_CONNECTION_STRING_FILE=$(absolute_path "$OPTARG")
+            ;;
+        r)
+            CACHE_CONTAINER="$OPTARG"
+            ;;
+        d)
+            CACHE_KEY_PREFIX="$OPTARG"
             ;;
         h)
             usage
@@ -62,7 +71,6 @@ function parse_options()
 
     (( OPTIND -= 1 )) || true
     shift $OPTIND || true
-    ORIG_ARGV=("$@")
 
     if [[ "$ENVIRONMENT_NAME" = "" ]]; then
         echo 'ERROR: please specify an environment name with -n.' >&2
@@ -80,8 +88,8 @@ function parse_options()
         echo 'ERROR: please specify an output tarball path with -o.' >&2
         exit 1
     fi
-    if [[ "$CACHE_PATH" != "" && ! -e "$CACHE_PATH" ]]; then
-        echo "ERROR: $CACHE_PATH does not exist." >&2
+    if [[ -n "$CACHE_CONNECTION_STRING_FILE" && -z "$CACHE_CONTAINER" ]]; then
+        echo "ERROR: if a cache connection string file is given, then an Azure Blob Storage container name must also be given." >&2
         exit 1
     fi
 }
@@ -93,8 +101,8 @@ if tty -s; then
 else
     TTY_ARGS=()
 fi
-if [[ "$CACHE_PATH" != "" ]]; then
-    CACHE_PATH_MOUNT_ARGS=(-v "$CACHE_PATH:/cache:delegated")
+if [[ -n "$CACHE_CONNECTION_STRING_FILE" ]]; then
+    CACHE_PATH_MOUNT_ARGS=(-v "$CACHE_CONNECTION_STRING_FILE:/azure-connection-string.txt:ro")
 else
     CACHE_PATH_MOUNT_ARGS=()
 fi
@@ -118,6 +126,8 @@ verbose_run docker run --rm --init "${TTY_ARGS[@]}" \
     "${CACHE_PATH_MOUNT_ARGS[@]}" \
     -e "ENVIRONMENT_NAME=$ENVIRONMENT_NAME" \
     -e "BUILD_CONCURRENCY=$BUILD_CONCURRENCY" \
+    -e "CACHE_CONTAINER=$CACHE_CONTAINER" \
+    -e "CACHE_KEY_PREFIX=$CACHE_KEY_PREFIX" \
     --user "$(id -u):$(id -g)" \
     "fullstaq/ruby-build-env-$ENVIRONMENT_NAME:$IMAGE_VERSION" \
     /system/container-entrypoints/build-jemalloc

--- a/build-ruby
+++ b/build-ruby
@@ -13,7 +13,9 @@ OUTPUT_PATH=
 VARIANT=normal
 JEMALLOC_BIN_PATH=
 BUILD_CONCURRENCY=1
-CACHE_PATH=
+CACHE_CONNECTION_STRING_FILE=
+CACHE_CONTAINER=
+CACHE_KEY_PREFIX=
 
 function usage()
 {
@@ -21,27 +23,28 @@ function usage()
     echo "Build a Ruby binary tarball from its source tarball."
     echo
     echo "Required options:"
-    echo "  -n NAME     Name of environment to build in (one of: $(list_environment_names "$SELFDIR/environments"))"
-    echo "  -s PATH     Path to Ruby source tarball"
-    echo "  -v VERSION  Package version number"
-    echo "  -o PATH     Path to output tarball"
+    echo "  -n NAME      Name of environment to build in (one of: $(list_environment_names "$SELFDIR/environments"))"
+    echo "  -s PATH      Path to Ruby source tarball"
+    echo "  -v VERSION   Package version number"
+    echo "  -o PATH      Path to output tarball"
     echo
     echo "Build variant (pick at most one):"
-    echo "  -m PATH     Build with Jemalloc support, using this Jemalloc binary tarball (as built by ./build-jemalloc)"
-    echo "  -t          Build with malloc_trim support"
+    echo "  -m PATH      Build with Jemalloc support, using this Jemalloc binary tarball (as built by ./build-jemalloc)"
+    echo "  -t           Build with malloc_trim support"
     echo
     echo "Optional options:"
-    echo "  -j NUM      Build concurrency (default: $BUILD_CONCURRENCY)"
-    echo "  -c PATH     Use given directory as cache"
-    echo "  -h          Show usage"
+    echo "  -j NUM       Build concurrency (default: $BUILD_CONCURRENCY)"
+    echo "  -c PATH      Cache to Azure Blob Storage, use connection string in given file"
+    echo "  -r CONTAINER Use given Azure Blob Storage container"
+    echo "  -d NAME      Use given Azure Blob Storage key prefix"
+    echo "  -h           Show usage"
 }
 
 function parse_options()
 {
     local OPTIND=1
-    local ORIG_ARGV
     local opt
-    while getopts "n:s:v:o:m:tj:c:h" opt; do
+    while getopts "n:s:v:o:m:tj:c:r:d:h" opt; do
         case "$opt" in
         n)
             ENVIRONMENT_NAME="$OPTARG"
@@ -66,7 +69,13 @@ function parse_options()
             BUILD_CONCURRENCY="$OPTARG"
             ;;
         c)
-            CACHE_PATH=$(absolute_path "$OPTARG")
+            CACHE_CONNECTION_STRING_FILE=$(absolute_path "$OPTARG")
+            ;;
+        r)
+            CACHE_CONTAINER="$OPTARG"
+            ;;
+        d)
+            CACHE_KEY_PREFIX="$OPTARG"
             ;;
         h)
             usage
@@ -80,7 +89,6 @@ function parse_options()
 
     (( OPTIND -= 1 )) || true
     shift $OPTIND || true
-    ORIG_ARGV=("$@")
 
     if [[ "$ENVIRONMENT_NAME" = "" ]]; then
         echo 'ERROR: please specify an environment name with -n.' >&2
@@ -112,8 +120,8 @@ function parse_options()
         echo 'ERROR: please specify an output tarball path with -o.' >&2
         exit 1
     fi
-    if [[ "$CACHE_PATH" != "" && ! -e "$CACHE_PATH" ]]; then
-        echo "ERROR: $CACHE_PATH does not exist." >&2
+    if [[ -n "$CACHE_CONNECTION_STRING_FILE" && -z "$CACHE_CONTAINER" ]]; then
+        echo "ERROR: if a cache connection string file is given, then an Azure Blob Storage container name must also be given." >&2
         exit 1
     fi
 }
@@ -129,8 +137,8 @@ MOUNT_ARGS=()
 if [[ "$VARIANT" = jemalloc ]]; then
     MOUNT_ARGS+=(-v "$JEMALLOC_BIN_PATH:/input/jemalloc-bin.tar.gz:ro")
 fi
-if [[ "$CACHE_PATH" != "" ]]; then
-    MOUNT_ARGS+=(-v "$CACHE_PATH:/cache:delegated")
+if [[ -n "$CACHE_CONNECTION_STRING_FILE" ]]; then
+    MOUNT_ARGS+=(-v "$CACHE_CONNECTION_STRING_FILE:/azure-connection-string.txt:ro")
 fi
 
 IMAGE_VERSION=$(read_single_value_file "$SELFDIR/environments/$ENVIRONMENT_NAME/image_tag")
@@ -154,6 +162,8 @@ verbose_run docker run --rm --init "${TTY_ARGS[@]}" \
     -e "BUILD_CONCURRENCY=$BUILD_CONCURRENCY" \
     -e "PACKAGE_VERSION=$PACKAGE_VERSION" \
     -e "ENVIRONMENT_NAME=$ENVIRONMENT_NAME" \
+    -e "CACHE_CONTAINER=$CACHE_CONTAINER" \
+    -e "CACHE_KEY_PREFIX=$CACHE_KEY_PREFIX" \
     --user "$(id -u):$(id -g)" \
     "fullstaq/ruby-build-env-$ENVIRONMENT_NAME:$IMAGE_VERSION" \
     /system/container-entrypoints/build-ruby

--- a/container-entrypoints/build-jemalloc
+++ b/container-entrypoints/build-jemalloc
@@ -19,14 +19,19 @@ BUILD_CONCURRENCY="${BUILD_CONCURRENCY:-1}"
 
 
 header "Setting up..."
-if [[ -e /cache ]]; then
-    echo "+ /cache is mounted in container, using it for ccache."
-    export CCACHE_DIR=/cache/ccache
-    export PATH="/usr/lib/ccache:$PATH"
-    echo "+ Activating ccache compilers in /usr/lib/ccache."
-    run mkdir -p "$CCACHE_DIR"
+if [[ -n "$CACHE_CONTAINER" ]]; then
+    echo "+ Caching enabled, will cache to Azure Blob Storage container $CACHE_CONTAINER."
+    require_container_mount /azure-connection-string.txt
+    SCCACHE_AZURE_CONNECTION_STRING=$(cat /azure-connection-string.txt)
+    export SCCACHE_AZURE_CONNECTION_STRING
+    export SCCACHE_AZURE_BLOB_CONTAINER="$CACHE_CONTAINER"
+    export SCCACHE_AZURE_KEY_PREFIX="$CACHE_KEY_PREFIX"
+    export SCCACHE_ERROR_LOG=/proc/$$/fd/2
+    SCCACHE_START_SERVER=1 sccache
+    export PATH="/usr/local/lib/sccache:$PATH"
+    echo "+ Activating ccache compilers in /usr/local/lib/sccache."
 else
-    echo "+ /cache is not mounted in the container, not using ccache."
+    echo "+ Caching disabled, not using sccache."
 fi
 echo
 
@@ -62,3 +67,6 @@ header "Packaging up..."
 echo "+ echo $ENVIRONMENT_NAME > $INSTALL_PREFIX/ENVIRONMENT"
 echo "$ENVIRONMENT_NAME" > "$INSTALL_PREFIX/ENVIRONMENT"
 run tar -czf "$OUTPUT_PATH" -C "$INSTALL_PREFIX" ENVIRONMENT include lib
+if [[ -n "$CACHE_CONTAINER" ]]; then
+    run sccache --stop-server
+fi

--- a/container-entrypoints/build-ruby
+++ b/container-entrypoints/build-ruby
@@ -39,14 +39,19 @@ export LD_RUN_PATH="$INSTALL_PREFIX/lib"
 
 
 header "Setting up..."
-if [[ -e /cache ]]; then
-    echo "+ /cache is mounted in container, using it for ccache."
-    export CCACHE_DIR=/cache/ccache
-    export PATH="/usr/lib/ccache:$PATH"
-    echo "+ Activating ccache compilers in /usr/lib/ccache."
-    run mkdir -p "$CCACHE_DIR"
+if [[ -n "$CACHE_CONTAINER" ]]; then
+    echo "+ Caching enabled, will cache to Azure Blob Storage container $CACHE_CONTAINER."
+    require_container_mount /azure-connection-string.txt
+    SCCACHE_AZURE_CONNECTION_STRING=$(cat /azure-connection-string.txt)
+    export SCCACHE_AZURE_CONNECTION_STRING
+    export SCCACHE_AZURE_BLOB_CONTAINER="$CACHE_CONTAINER"
+    export SCCACHE_AZURE_KEY_PREFIX="$CACHE_KEY_PREFIX"
+    export SCCACHE_ERROR_LOG=/proc/$$/fd/2
+    SCCACHE_START_SERVER=1 sccache
+    export PATH="/usr/local/lib/sccache:$PATH"
+    echo "+ Activating ccache compilers in /usr/local/lib/sccache."
 else
-    echo "+ /cache is not mounted in the container, not using ccache."
+    echo "+ Caching disabled, not using sccache."
 fi
 echo
 
@@ -147,3 +152,6 @@ echo "$VARIANT" > "$DESTDIR/VARIANT"
 echo "+ echo $ENVIRONMENT_NAME > $DESTDIR/ENVIRONMENT"
 echo "$ENVIRONMENT_NAME" > "$DESTDIR/ENVIRONMENT"
 run tar -czf "$OUTPUT_PATH" -C "$DESTDIR" .
+if [[ -n "$CACHE_CONTAINER" ]]; then
+    run sccache --stop-server
+fi

--- a/dev-handbook/README.md
+++ b/dev-handbook/README.md
@@ -15,6 +15,7 @@
 
  * [CI/CD system resumption support](ci-cd-resumption.md)
  * [CI/CD system and splitting into multiple workflows](ci-cd-split-multiple-workflows.md)
+ * [CI/CD caching](ci-cd-caching.md)
  * [APT and YUM repository setup](apt-yum-repo.md)
 
 ## Tutorials & tasks

--- a/dev-handbook/add-new-distro.md
+++ b/dev-handbook/add-new-distro.md
@@ -15,7 +15,7 @@ Create a new directory `environments/<DISTRO NAME>-<DISTRO VERSION>` (for exampl
     - Ensure its `FROM` is set to an appropriate image that corresponds to the distribution and version you want to support. For example `FROM centos:16`.
     - Ensure it has a user account named `builder`, and that the Dockerfile's `USER` directive is set to that account.
     - Ensure a C and C++ compiler toolchain is installed.
-    - Ensure ccache is installed and configured.
+    - Ensure [sccache](https://github.com/mozilla/sccache) is installed and configured.
     - Ensure development headers for OpenSSL, zlib, FFI, readline, ncurses and GDBM are installed.
 
  * An `image_tag`. This file is used for [versioning](build-environments.md#versioning). Since this is a new file, set its contents to `1`.

--- a/dev-handbook/ci-cd-caching.md
+++ b/dev-handbook/ci-cd-caching.md
@@ -1,0 +1,26 @@
+# CI/CD caching
+
+The CI/CD system caches C/C++ compiler invocations using [sccache](https://github.com/mozilla/sccache). Sccache is a C/C++/Rust compiler cacher, similar to [ccache](https://ccache.dev/), but caches to cloud storage instead of the local filesystem.
+
+We used to use ccache, in combination with Github's [cache action](https://github.com/actions/cache) to cache the ccache directory. We had a unique ccache directory on a per-distribution, per-Ruby version and per-variant basis. But each ccache directory can be huge (hundreds of MBs or several GBs). This gave rise to several problems:
+
+ * Because [we build so many different packages](build-workflow-management.md), we easily exceed the Github Actions cache storage limit of 10 GB.
+ * Downloading/uploading the entire ccache directory takes a significant amount of time.
+ * Ccache may not need to access all files in the ccache directory, so downloading the entire ccache directory can be overkill.
+ * Variants have many similarities, and so we should be able to achieve a reasonable cache hit rate if compilations of different variants (given the same distribution and Ruby version) share the same cache. With the ccache approach, cache sharing between different CI jobs is very difficult.
+ * CI jobs for Git branches can't warm up the cache for the CI job that will run when the branch is merged to main.
+
+Sccache solves all of the above problems. We cache Azure Blob Storage. All CI jobs access the same Azure Blob Storage container, but we divide that container into multiple separate logical caches by using prefixes (directory names). We assign a unique prefix only on a per-distribution basis. This means that all CI jobs targeting the same distribution can share the same cache, regardless of the Ruby version or variant being compiled, and regardless of the branch.
+
+> Trivia: we [contributed the ability to specify a prefix within Azure Blob Storage](https://github.com/mozilla/sccache/pull/1109) so that we can use sccache in Fullstaq Ruby.
+
+## Why Azure Blob Storage?
+
+The choice of Azure Blob Storage may seem odd given the fact that [the rest of our infrastructure is hosted on Google Cloud](https://github.com/fullstaq-ruby/infra/blob/main/docs/infrastructure-overview.md). The reason is performance. Github-hosted Actions runners are hosted on Azure. [Research has shown](https://github.com/fullstaq-ruby/server-edition/issues/86#issuecomment-1032643774) that latency between Azure and Google Cloud Storage is pretty abysmal: caching to Google Cloud Storage actually makes things **slower**, even if the runner and the Google Cloud Storage bucket are located near each other. In contrast, latency between runners and Azure Blob Storage is very good, even if runners are located on two opposite sides of the US continent.
+
+## Performance impact
+
+The use of sccache impacts performance as follows (compared to not using sccache):
+
+ * Cold compilations are ~28% slower.
+ * Hot compilations are ~56% faster.

--- a/environments/centos-7/Dockerfile
+++ b/environments/centos-7/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:7
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -13,24 +13,35 @@ RUN set -x && \
     yum install -y --enablerepo epel \
         gcc gcc-c++ make patch bzip2 curl autoconf automake \
         openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel \
-        gdbm-devel ncurses-devel ccache && \
+        gdbm-devel ncurses-devel && \
+    yum clean all && \
+    rm -rf /tmp/* /var/tmp/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.3/activatecontaineruid-0.9.3-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     groupadd --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --password '#' builder && \
-    yum clean all && \
-    if ! test -e /usr/lib/ccache/cc; then \
-        mkdir -p /usr/lib/ccache && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/cc && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/gcc && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/c++ && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/g++; \
-    fi
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/centos-7/image_tag
+++ b/environments/centos-7/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-3
+4

--- a/environments/centos-8/Dockerfile
+++ b/environments/centos-8/Dockerfile
@@ -1,8 +1,8 @@
 FROM rockylinux:8
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -13,24 +13,35 @@ RUN set -x && \
     dnf install -y --enablerepo epel --enablerepo powertools \
         findutils gcc gcc-c++ make patch bzip2 curl autoconf automake \
         openssl-devel libyaml-devel libffi-devel readline-devel zlib-devel \
-        gdbm-devel ncurses-devel ccache && \
+        gdbm-devel ncurses-devel && \
+    dnf clean all && \
+    rm -rf /tmp/* /var/tmp/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo -e '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.3/activatecontaineruid-0.9.3-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     groupadd --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --password '#' builder && \
-    dnf clean all && \
-    if ! test -e /usr/lib/ccache/cc; then \
-        mkdir -p /usr/lib/ccache && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/cc && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/gcc && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/c++ && \
-        ln -s /usr/bin/ccache /usr/lib/ccache/g++; \
-    fi
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/centos-8/image_tag
+++ b/environments/centos-8/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/environments/debian-10/Dockerfile
+++ b/environments/debian-10/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:10
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -11,21 +11,38 @@ LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-
 RUN set -x && \
     apt update && \
     apt install -y autoconf bison bzip2 build-essential \
-        dpkg-dev curl ca-certificates ccache \
+        dpkg-dev curl ca-certificates \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
         libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+    apt clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.2/activatecontaineruid-0.9.2-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     addgroup --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
     usermod -L builder && \
-    apt clean && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/debian-10/image_tag
+++ b/environments/debian-10/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-1
+2

--- a/environments/debian-11/Dockerfile
+++ b/environments/debian-11/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:11
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -11,21 +11,38 @@ LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-
 RUN set -x && \
     apt update && \
     apt install -y autoconf bison bzip2 build-essential \
-        dpkg-dev curl ca-certificates ccache \
+        dpkg-dev curl ca-certificates \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
         libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+    apt clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.2/activatecontaineruid-0.9.2-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     addgroup --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
     usermod -L builder && \
-    apt clean && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/debian-11/image_tag
+++ b/environments/debian-11/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-1
+2

--- a/environments/debian-9/Dockerfile
+++ b/environments/debian-9/Dockerfile
@@ -1,8 +1,8 @@
 FROM debian:9
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -11,21 +11,38 @@ LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-
 RUN set -x && \
     apt update && \
     apt install -y autoconf bison bzip2 build-essential \
-        dpkg-dev curl ca-certificates ccache \
+        dpkg-dev curl ca-certificates \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
         libncurses5-dev libffi-dev libgdbm3 libgdbm-dev && \
+    apt clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.2/activatecontaineruid-0.9.2-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     addgroup --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
     usermod -L builder && \
-    apt clean && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/debian-9/image_tag
+++ b/environments/debian-9/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/environments/ubuntu-18.04/Dockerfile
+++ b/environments/ubuntu-18.04/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:18.04
 
-# Used to link container image to the repo: 
+# Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -11,21 +11,38 @@ LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-
 RUN set -x && \
     apt update && \
     apt install -y autoconf bison bzip2 build-essential \
-        dpkg-dev curl ca-certificates ccache \
+        dpkg-dev curl ca-certificates \
     	libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
     	libncurses5-dev libffi-dev libgdbm5 libgdbm-dev && \
+    apt clean && \
+    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
     \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.2/activatecontaineruid-0.9.2-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
     addgroup --gid 9999 builder && \
     adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
     usermod -L builder && \
-    apt clean && \
-    rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
+    rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/ubuntu-18.04/image_tag
+++ b/environments/ubuntu-18.04/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/environments/ubuntu-20.04/Dockerfile
+++ b/environments/ubuntu-20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -11,28 +11,37 @@ LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-
 RUN set -x && \
     apt update && \
     apt install -y autoconf bison bzip2 build-essential \
-        dpkg-dev curl ca-certificates ccache \
+        dpkg-dev curl ca-certificates \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
         libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
-    \
-    curl -sSLo /sbin/activatecontaineruid.gz https://github.com/fullstaq-labs/activatecontaineruid/releases/download/v0.9.3/activatecontaineruid-0.9.3-x86_64-linux.gz && \
-    gunzip /sbin/activatecontaineruid.gz && \
-    chmod +x,+s /sbin/activatecontaineruid && \
-    mkdir /etc/activatecontaineruid && \
-    echo 'app_account: builder' > /etc/activatecontaineruid/config.yml && \
-    \
-    addgroup --gid 9999 builder && \
-    adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
-    usermod -L builder && \
-    \
-    # Fixes https://github.com/fullstaq-labs/fullstaq-ruby-server-edition/issues/80 \
-    # Problem summary: https://github.com/fullstaq-labs/fullstaq-ruby-server-edition/pull/82 \
-    cp /bin/mkdir /bin/mkdir2 && \
-    rm -f /usr/bin/mkdir && \
-    mv /bin/mkdir2 /bin/mkdir && \
-    \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
+# RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/download/v0.3.0/sccache-v0.2.16-x86_64-unknown-linux-musl.tar.gz && \
+#     tar xzf sccache.tar.gz && \
+#     mv sccache-*/sccache /usr/local/bin/ && \
+RUN curl -fsSLo sccache.gz https://github.com/FooBarWidget/sccache/releases/download/v0.2.16/sccache.gz && \
+    gunzip sccache.gz && \
+    mv sccache /usr/local/bin/ && \
+    chmod +x /usr/local/bin/sccache && \
+    chown root: /usr/local/bin/sccache && \
+    rm -rf sccache-* && \
+    mkdir /usr/local/lib/sccache && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/cc "$@"' > /usr/local/lib/sccache/cc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/c++ "$@"' > /usr/local/lib/sccache/c++ && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/gcc "$@"' > /usr/local/lib/sccache/gcc && \
+    echo '#!/bin/sh\nexec /usr/local/bin/sccache /usr/bin/g++ "$@"' > /usr/local/lib/sccache/g++ && \
+    chmod +x /usr/local/lib/sccache/* && \
+    \
+    curl -fsSLo /sbin/matchhostfsowner.gz https://github.com/FooBarWidget/matchhostfsowner/releases/download/v0.9.8/matchhostfsowner-0.9.8-x86_64-linux.gz && \
+    gunzip /sbin/matchhostfsowner.gz && \
+    chmod +x,+s /sbin/matchhostfsowner && \
+    mkdir /etc/matchhostfsowner && \
+    echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
+    \
+    addgroup --gid 9999 builder && \
+    adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
+    usermod -L builder
+
 USER builder
-ENTRYPOINT ["/sbin/activatecontaineruid"]
+ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/ubuntu-20.04/image_tag
+++ b/environments/ubuntu-20.04/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/environments/utility/Dockerfile
+++ b/environments/utility/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:18.04
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-labs/fullstaq-ruby-server-edition
+LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is


### PR DESCRIPTION
Closes #86.

This requires https://github.com/mozilla/sccache/pull/1109, which has been merged but hasn't been released yet. Therefore we use our own sccache binary which includes this feature. We'll use the upstream binary once sccache 0.3.0 is out.

In the Ubuntu 20.04 image, this undoes a fix for #80 because that fix never worked in the first place. See #101.