### PR TITLE
Update Readme, quoting is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,10 +745,10 @@ sudo apt install unattended-upgrades
 
 Then in `/etc/apt/apt.conf.d/50unattended-upgrades`, add `origin=Fullstaq Ruby` to `Unattended-Upgrade::Origins-Pattern`, like this:
 
-```
+```python
 Unattended-Upgrade::Origins-Pattern {
     ...
-    "origin=Fullstaq Ruby";
+    "origin='Fullstaq Ruby'";
 }
 ```
 


### PR DESCRIPTION
At least in my environment unquoted `Fullstaq Ruby` cause an error.

```bash
#21 4.882 An error occurred: too many values to unpack (expected 2)
#21 4.882 Traceback (most recent call last):
#21 4.882   File "/usr/bin/unattended-upgrade", line 1985, in main
#21 4.882     res = run(options, rootdir, mem_log, logfile_dpkg,
#21 4.882   File "/usr/bin/unattended-upgrade", line 2126, in run
#21 4.882     cache = UnattendedUpgradesCache(rootdir=rootdir)
#21 4.882   File "/usr/bin/unattended-upgrade", line 171, in __init__
#21 4.882     apt.Cache.__init__(self, rootdir=rootdir)
#21 4.882   File "/usr/lib/python3/dist-packages/apt/cache.py", line 170, in __init__
#21 4.882     self.open(progress)
#21 4.882   File "/usr/bin/unattended-upgrade", line 333, in open
#21 4.882     self.apply_pinning(self.pinning_from_config())
#21 4.882   File "/usr/bin/unattended-upgrade", line 279, in pinning_from_config
#21 4.882     if not is_allowed_origin(pkg_file, self.allowed_origins):
#21 4.882   File "/usr/bin/unattended-upgrade", line 973, in is_allowed_origin
#21 4.882     if match_whitelist_string(allowed, origin):
#21 4.882   File "/usr/bin/unattended-upgrade", line 812, in match_whitelist_string
#21 4.882     (what, value) = [s.strip().replace("%2C", ",")
#21 4.882 ValueError: too many values to unpack (expected 2)
```