### PR TITLE
GHA use docker/login-action for ghcr.io login

### DIFF
--- a/.github/workflows/ci-cd-prepare.yml
+++ b/.github/workflows/ci-cd-prepare.yml
@@ -685,9 +685,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download utility Docker image
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -752,9 +754,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download utility Docker image
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -827,9 +831,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Rbenv source
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -907,9 +913,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Rbenv source
         run: ./internal-scripts/ci-cd/download-artifact.sh

--- a/.github/workflows/ci-cd-prepare.yml.erb
+++ b/.github/workflows/ci-cd-prepare.yml.erb
@@ -284,9 +284,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download utility Docker image
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -351,9 +353,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download utility Docker image
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -426,9 +430,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Rbenv source
         run: ./internal-scripts/ci-cd/download-artifact.sh
@@ -506,9 +512,11 @@ jobs:
         with:
           version: '>= 363.0.0'
       - name: Login to Github Container Registry
-        run: docker login ghcr.io -u ${{ github.actor }} --password-stdin <<<"$GITHUB_TOKEN"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch Rbenv source
         run: ./internal-scripts/ci-cd/download-artifact.sh


### PR DESCRIPTION
Use standard `docker/login-action` to login to ghcr.io registry.