### PR TITLE
Lint LABEL usage in enviroments Dockerfile

### DIFF
--- a/environments/centos-8/Dockerfile
+++ b/environments/centos-8/Dockerfile
@@ -2,7 +2,7 @@ FROM rockylinux:8
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is

--- a/environments/debian-11/Dockerfile
+++ b/environments/debian-11/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:11
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -47,5 +47,5 @@ RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/downl
     rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENV PATH /home/builder/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/home/builder/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/debian-12/Dockerfile
+++ b/environments/debian-12/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:12
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is
@@ -44,5 +44,5 @@ RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/downl
     rm -rf /tmp/* /var/tmp/*
 
 USER builder
-ENV PATH /home/builder/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PATH=/home/builder/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENTRYPOINT ["/sbin/matchhostfsowner"]

--- a/environments/el-9/Dockerfile
+++ b/environments/el-9/Dockerfile
@@ -2,7 +2,7 @@ FROM rockylinux:9
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is

--- a/environments/ubuntu-22.04/Dockerfile
+++ b/environments/ubuntu-22.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is

--- a/environments/ubuntu-24.04/Dockerfile
+++ b/environments/ubuntu-24.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is

--- a/environments/utility/Dockerfile
+++ b/environments/utility/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 # Used to link container image to the repo:
 # https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/connecting-a-repository-to-a-container-image#connecting-a-repository-to-a-container-image-on-the-command-line
-LABEL org.opencontainers.image.source https://github.com/fullstaq-ruby/server-edition
+LABEL org.opencontainers.image.source=https://github.com/fullstaq-ruby/server-edition
 
 # If you make a change and you want to force users to re-pull the image
 # (e.g. when your change adds a feature that our scripts rely on, or is


### PR DESCRIPTION
Minor linting cleanup of environments Dockerfiles

```
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 5)
 ```