### PR TITLE
Debian 13 test fixes - apt-key removed

### DIFF
--- a/.github/workflows/ci-cd-prepare.yml
+++ b/.github/workflows/ci-cd-prepare.yml
@@ -282,14 +282,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-13-v1'
+          IMAGE_TAG: 'debian-13-v2'
           SOURCE_DIR: 'environments/debian-13'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-13-v1'
+          IMAGE_TAG: 'debian-13-v2'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:

--- a/.github/workflows/ci-cd-prepare.yml
+++ b/.github/workflows/ci-cd-prepare.yml
@@ -198,14 +198,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-11-v3'
+          IMAGE_TAG: 'debian-11-v4'
           SOURCE_DIR: 'environments/debian-11'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-11-v3'
+          IMAGE_TAG: 'debian-11-v4'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -240,14 +240,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-12-v2'
+          IMAGE_TAG: 'debian-12-v3'
           SOURCE_DIR: 'environments/debian-12'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'debian-12-v2'
+          IMAGE_TAG: 'debian-12-v3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -366,14 +366,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'ubuntu-22.04-v3'
+          IMAGE_TAG: 'ubuntu-22.04-v4'
           SOURCE_DIR: 'environments/ubuntu-22.04'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'ubuntu-22.04-v3'
+          IMAGE_TAG: 'ubuntu-22.04-v4'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -408,14 +408,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'ubuntu-24.04-v1'
+          IMAGE_TAG: 'ubuntu-24.04-v2'
           SOURCE_DIR: 'environments/ubuntu-24.04'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'ubuntu-24.04-v1'
+          IMAGE_TAG: 'ubuntu-24.04-v2'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:
@@ -450,14 +450,14 @@ jobs:
         run: ./internal-scripts/ci-cd/build-docker-images/build.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'utility-v2'
+          IMAGE_TAG: 'utility-v3'
           SOURCE_DIR: 'environments/utility'
 
       - name: Dump image
         run: ./internal-scripts/ci-cd/build-docker-images/dump-image.sh
         env:
           IMAGE_NAME: 'ghcr.io/fullstaq-ruby/server-edition-ci-images'
-          IMAGE_TAG: 'utility-v2'
+          IMAGE_TAG: 'utility-v3'
       - name: Archive artifact
         run: ./internal-scripts/ci-cd/upload-artifact.sh
         env:

--- a/environments/debian-11/Dockerfile
+++ b/environments/debian-11/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
     apt install -y autoconf bison bzip2 build-essential \
         dpkg-dev curl ca-certificates pkg-config \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
-        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
+        gpg && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/debian-11/image_tag
+++ b/environments/debian-11/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-3
+4

--- a/environments/debian-12/Dockerfile
+++ b/environments/debian-12/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
     apt install -y autoconf bison bzip2 build-essential \
         dpkg-dev curl ca-certificates pkg-config rustc \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
-        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
+        gpg && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/debian-12/image_tag
+++ b/environments/debian-12/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/environments/debian-13/Dockerfile
+++ b/environments/debian-13/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x && \
         dpkg-dev curl ca-certificates pkg-config rustc \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
         libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
-        adduser && \
+        gpg adduser && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/debian-13/Dockerfile
+++ b/environments/debian-13/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
     apt install -y autoconf bison bzip2 build-essential \
         dpkg-dev curl ca-certificates pkg-config rustc \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
-        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
+        adduser && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 
@@ -36,8 +37,8 @@ RUN curl -fsSLo sccache.tar.gz https://github.com/mozilla/sccache/releases/downl
     mkdir /etc/matchhostfsowner && \
     echo 'app_account: builder' > /etc/matchhostfsowner/config.yml && \
     \
-    groupadd --gid 9999 builder && \
-    useradd --uid 9999 --gid 9999 --comment Builder --create-home builder && \
+    addgroup --gid 9999 builder && \
+    adduser --uid 9999 --gid 9999 --disabled-password --gecos Builder builder && \
     usermod -L builder && \
     \
     rm -rf /tmp/* /var/tmp/*

--- a/environments/debian-13/image_tag
+++ b/environments/debian-13/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-1
+2

--- a/environments/ubuntu-22.04/Dockerfile
+++ b/environments/ubuntu-22.04/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
     apt install -y autoconf bison bzip2 build-essential \
         dpkg-dev curl ca-certificates pkg-config rustc \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
-        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
+        gpg && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/ubuntu-22.04/image_tag
+++ b/environments/ubuntu-22.04/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-3
+4

--- a/environments/ubuntu-24.04/Dockerfile
+++ b/environments/ubuntu-24.04/Dockerfile
@@ -13,7 +13,8 @@ RUN set -x && \
     apt install -y autoconf bison bzip2 build-essential \
         dpkg-dev curl ca-certificates pkg-config rustc \
         libssl-dev libyaml-dev libreadline-dev zlib1g-dev \
-        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev && \
+        libncurses5-dev libffi-dev libgdbm6 libgdbm-dev \
+        gpg && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/ubuntu-24.04/image_tag
+++ b/environments/ubuntu-24.04/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-1
+2

--- a/environments/utility/Dockerfile
+++ b/environments/utility/Dockerfile
@@ -14,7 +14,7 @@ RUN set -x && \
     apt update && \
     apt install -y wget ca-certificates binutils build-essential \
         curl ca-certificates rpm file ruby ruby-dev rubygems sudo \
-        aptly createrepo-c parallel && \
+        aptly createrepo-c parallel gpg && \
     apt clean && \
     rm -rf /tmp/* /var/tmp/* /var/lib/apt/lists/*
 

--- a/environments/utility/image_tag
+++ b/environments/utility/image_tag
@@ -1,4 +1,4 @@
 # Bump this version whenever you've made a change and you want
 # to force users to re-pull the image (e.g. when your change adds
 # a feature that our scripts rely on, or is breaking).
-2
+3

--- a/internal-scripts/ci-cd/publish/install-aptly.sh
+++ b/internal-scripts/ci-cd/publish/install-aptly.sh
@@ -9,6 +9,6 @@ source "$ROOTDIR/lib/library.sh"
 echo '+ Adding Aptly repo'
 echo deb http://repo.aptly.info/ squeeze main | sudo tee /etc/apt/sources.list.d/aptly.list
 echo '+ Adding Aptly public key'
-curl -fsSL https://www.aptly.info/pubkey.txt | sudo apt-key add -
+curl -fsSL https://www.aptly.info/pubkey.txt | sudo gpg --dearmor -o /etc/apt/trusted.gpg.d/aptly.gpg
 run sudo apt update
 run sudo apt install -y aptly

--- a/internal-scripts/test-debs
+++ b/internal-scripts/test-debs
@@ -31,7 +31,7 @@ if [[ "$SERVER" = "" ]]; then
 else
     run apt update
     run apt install -y "${ESSENTIAL_PACKAGES[@]}" gnupg apt-transport-https ca-certificates
-    run apt-key add /system/fullstaq-ruby.asc
+    run gpg --dearmor -o "/etc/apt/trusted.gpg.d/fullstaq-ruby.gpg" /system/fullstaq-ruby.asc
     echo "+ Create /etc/apt/sources.list.d/server.list"
     echo "deb $SERVER $APT_DISTRO_NAME main" > /etc/apt/sources.list.d/server.list
     cat /etc/apt/sources.list.d/server.list


### PR DESCRIPTION
Switch to using `/etc/apt/trusted.gpg.d/` for apt key management. `apt-key` was removed in Debian 13.

`/etc/apt/trusted.gpg.d/` is compatible with supported enviroments Ubuntu 18.04+ and Debian 11+

Added `adduser` in Debian 13 for compatibility with test scripts.